### PR TITLE
feat(quantizer): op whitelist for mixed-precision QAT + torch 2.9 compat

### DIFF
--- a/utils/ax_quantizer.py
+++ b/utils/ax_quantizer.py
@@ -373,9 +373,11 @@ class AXQuantizer(Quantizer):
         "split",
     ]
 
-    def __init__(self, config_file: str, is_qat: bool = True, annotate_bias: bool = True) -> None:
+    def __init__(self, config_file: str, is_qat: bool = True, annotate_bias: bool = True, quant_ops: Optional[List[str]] = None) -> None:
         super().__init__()
         self._annotate_bias = annotate_bias
+        # 量化算子白名单：None=全部；指定时只量化列出的算子（其余保持 FP32）
+        self._quant_ops = set(quant_ops) if quant_ops else None
 
         # init config
         self.init_global()
@@ -442,6 +444,8 @@ class AXQuantizer(Quantizer):
         # global
         assert self.global_config is not None
         for op in self.OPS:
+            if self._quant_ops is not None and op not in self._quant_ops:
+                continue
             OP_TO_ANNOTATOR[op](model, self.global_config, is_global=True)
         propagate_annotation(model, self.global_config)
 

--- a/utils/ax_quantizer_utils.py
+++ b/utils/ax_quantizer_utils.py
@@ -383,9 +383,7 @@ def _annotate_conv(
     gm.graph.eliminate_dead_code()
     gm.recompile()
 
-    from torch._export import gm_using_training_ir
-
-    using_training_ir = gm_using_training_ir(gm)
+    using_training_ir = True  # torch2.9: export_for_training 输出即 training IR
 
     # example_inputs
     _conv1d_example_inputs = (
@@ -442,7 +440,7 @@ def _annotate_conv(
     # Match against all conv dimensions and cuda variants
     for (conv_fn, has_bn, example_inputs), is_cuda, activation in combinations:  # type: ignore[misc]
         pattern = get_pattern(conv_fn, has_bn, activation)  # type: ignore[has-type]
-        pattern = _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda, using_training_ir=using_training_ir)  # type: ignore[has-type]
+        pattern = _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda)  # type: ignore[has-type]
         pattern.graph.eliminate_dead_code()
         pattern.recompile()
         matcher = SubgraphMatcherWithNameNodeMap(pattern, ignore_literals=True)
@@ -560,9 +558,7 @@ def _annotate_convtranspose(
     gm.graph.eliminate_dead_code()
     gm.recompile()
 
-    from torch._export import gm_using_training_ir
-
-    using_training_ir = gm_using_training_ir(gm)
+    using_training_ir = True  # torch2.9: export_for_training 输出即 training IR
 
     # example_inputs
     _conv1d_example_inputs = (
@@ -619,7 +615,7 @@ def _annotate_convtranspose(
     # Match against all conv dimensions and cuda variants
     for (conv_fn, has_bn, example_inputs), is_cuda, activation in combinations:  # type: ignore[misc]
         pattern = get_pattern(conv_fn, has_bn, activation)  # type: ignore[has-type]
-        pattern = _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda, using_training_ir=using_training_ir)  # type: ignore[has-type]
+        pattern = _get_aten_graph_module_for_pattern(pattern, example_inputs, is_cuda)  # type: ignore[has-type]
         pattern.graph.eliminate_dead_code()
         pattern.recompile()
         matcher = SubgraphMatcherWithNameNodeMap(pattern, ignore_literals=True)


### PR DESCRIPTION
## Summary
- `AXQuantizer` 新增 `quant_ops` 参数：只量化指定的算子类型，其余保持 FP32，支持混合精度 QAT 图（例如排除 Mul，避免 elementwise 权重输入在 pulsar2 QDQ 导入时的 scale 匹配问题）。
- `ax_quantizer_utils`：适配 torch>=2.9（`torch._export.gm_using_training_ir` 已移除，直接用 `True`，因为 `export_for_training` 输出即 training IR）。

## Usage
```python
quantizer = AXQuantizer(config, quant_ops=["conv", "convtranspose", "matmul"])
```

## Verified
- htdemucs（4-stem 音乐分离）QAT 导出验证：`quant_ops` 排除 Mul 后 ONNX 中 Mul 保持 FP32，其余算子正常 QDQ。
- torch 2.9.1 + PT2E 全流程（export → prepare_qat_pt2e → convert_pt2e → ONNX）跑通。